### PR TITLE
Restore git provenance embedding under Gradle 9

### DIFF
--- a/build-git.gradle
+++ b/build-git.gradle
@@ -1,85 +1,95 @@
-ext.getGitHash = { ->
+// Build-time git provenance, embedded into the jar as build.githash / .gitbranch /
+// .gitremoteurl / .date resources and read back at runtime by
+// org.opensha.commons.util.GitVersion.
+//
+// These resources are the *only* provenance mechanism that works in a deployed
+// container, which carries the jar but no git checkout. If they go missing, GitVersion
+// falls back to shelling out to git against a source tree that may not exist. Keep the
+// warnings below loud: a silent failure here previously shipped metadata-less jars for
+// two months (Project.exec was removed in Gradle 9, every call threw, and every throw
+// was swallowed).
+
+/**
+ * Runs a git command in projectDir and returns its trimmed stdout, or "" on any failure.
+ *
+ * Uses ProcessBuilder rather than Gradle's exec/ExecOperations: writeBuildFiles runs at
+ * execution time so there is nothing to gain from a lazy provider, and ProcessBuilder is
+ * not subject to Gradle API churn. stderr is captured separately rather than merged, so
+ * an advisory git warning cannot end up inside a commit hash.
+ */
+ext.gitOutput = { List<String> cmd ->
     try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--short', 'HEAD'
-            standardOutput = stdout
+        def proc = new ProcessBuilder(cmd).directory(projectDir).start()
+        // Output here is a hash, a branch name or a URL — far below the pipe buffer, so
+        // draining the streams in sequence cannot deadlock.
+        def out = proc.inputStream.getText('UTF-8').trim()
+        def err = proc.errorStream.getText('UTF-8').trim()
+        if (proc.waitFor() != 0) {
+            logger.warn("git ${cmd.join(' ')} failed in ${projectDir}: ${err}")
+            return ""
         }
-        return stdout.toString().trim()
+        return out
     } catch (Exception e) {
+        logger.warn("could not run git ${cmd.join(' ')} in ${projectDir}: ${e.message}")
         return ""
     }
+}
+
+ext.getGitHash = { ->
+    gitOutput(['git', 'rev-parse', '--short', 'HEAD'])
 }
 
 ext.getGitLongHash = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', 'HEAD'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
-    }
+    gitOutput(['git', 'rev-parse', 'HEAD'])
 }
 
 ext.getGitBranch = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
+    def branch = gitOutput(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+    if (branch == 'HEAD') {
+        // Detached HEAD — how actions/checkout leaves a clone pinned to a ref, and how
+        // the release build runs. Deliberately NOT GITHUB_REF_NAME: in the nzshm-opensha
+        // build that variable names *that* repo's ref, so using it here would stamp the
+        // wrong repository's identity into this repository's provenance.
+        branch = gitOutput(['git', 'name-rev', '--name-only', '--always', 'HEAD'])
+                .replaceFirst(/^remotes\/origin\//, '')
     }
+    return branch
 }
 
 ext.getGitRemoteUrl = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'name-rev', '--name-only', 'HEAD'
-            standardOutput = stdout
-        }
-        def branch = stdout.toString().trim()
-
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'config', 'branch.' + branch + '.remote'
-            standardOutput = stdout
-        }
-        def remote = stdout.toString().trim()
-
-        stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'config', 'remote.' + remote + '.url'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
-    }
+    // Asks origin directly. The old implementation walked
+    // name-rev -> branch.<name>.remote -> remote.<name>.url, which yields nothing
+    // whenever HEAD sits on a tag (name-rev returns "tags/...", which is not a branch,
+    // so the lookup collapses to the literal `git config remote.null.url`).
+    gitOutput(['git', 'remote', 'get-url', 'origin'])
 }
 
 ext.writeBuildFiles = { prefix='build' ->
-    logger.info("Writing build.date file")
+    logger.info("Writing ${prefix}.date file")
     new File(projectDir, prefix+".date").text = new Date().toString()+"\n"+System.currentTimeMillis()+"\n"
+
     String hash = getGitLongHash()
     if (hash?.trim()) {
-        logger.info("Writing build.githash file: "+hash)
+        logger.info("Writing ${prefix}.githash file: "+hash)
         new File(projectDir, prefix+".githash").text = hash+"\n"
+    } else {
+        logger.warn("${prefix}.githash NOT written - git hash unavailable in ${projectDir}; "
+                + "the jar will carry no commit provenance")
     }
+
     String branch = getGitBranch()
     if (branch?.trim()) {
-        logger.info("Writing build.gitbranch file: "+branch)
+        logger.info("Writing ${prefix}.gitbranch file: "+branch)
         new File(projectDir, prefix+".gitbranch").text = branch+"\n"
+    } else {
+        logger.warn("${prefix}.gitbranch NOT written - git branch unavailable in ${projectDir}")
     }
+
     String remoteUrl = getGitRemoteUrl()
     if (remoteUrl?.trim()) {
-        logger.info("Writing build.gitremoteurl file: "+remoteUrl)
+        logger.info("Writing ${prefix}.gitremoteurl file: "+remoteUrl)
         new File(projectDir, prefix+".gitremoteurl").text = remoteUrl+"\n"
+    } else {
+        logger.warn("${prefix}.gitremoteurl NOT written - git remote unavailable in ${projectDir}")
     }
 }

--- a/src/main/java/org/opensha/commons/util/GitVersion.java
+++ b/src/main/java/org/opensha/commons/util/GitVersion.java
@@ -39,16 +39,27 @@ public class GitVersion {
     }
 
     public static List<String> execute(String[] command, File directory) {
+        // A missing working directory is reported by the JVM as "Cannot run program ... error=2,
+        // No such file or directory" — indistinguishable from a missing git binary, and alarming
+        // in a log. Check first so an absent source tree (the normal case in a deployed
+        // container, which carries the jar but no checkout) is one quiet line instead.
+        if (directory != null && !directory.isDirectory()) {
+            System.err.println("Skipping " + String.join(" ", command)
+                    + " : not a directory: " + directory);
+            return null;
+        }
         try {
             Process p = Runtime.getRuntime().exec(command, null, directory);
             int exit = p.waitFor();
             if (exit != 0) {
+                System.err.println("Command " + String.join(" ", command)
+                        + " exited " + exit + " in " + directory);
                 return null;
             }
             return FileUtils.loadStream(p.getInputStream());
         } catch (Exception e) {
-            System.err.println("Exception executing command " + String.join(" ", command) + " : " + e.getMessage());
-            e.printStackTrace();
+            System.err.println("Could not execute " + String.join(" ", command)
+                    + " in " + directory + " : " + e.getMessage());
             return null;
         }
     }
@@ -85,9 +96,11 @@ public class GitVersion {
             System.out.println(gitBranchFileName + " resource not found.");
         }
 
-        File cwd = new File("").getAbsoluteFile();
+        // Must run against baseDirectory, like loadGitHash and loadGitRemote. This used to use
+        // the process cwd, which meant the branch of whatever repository happened to launch the
+        // JVM got reported as this repository's branch — wrong data rather than absent data.
         String[] command = {"git", "rev-parse", "--abbrev-ref", "HEAD"};
-        return first(execute(command, cwd));
+        return first(execute(command, baseDirectory));
     }
 
     public String loadGitRemote() throws IOException {
@@ -104,11 +117,11 @@ public class GitVersion {
             System.out.println(gitBranchFileName + " resource not found.");
         }
 
-        String[] command = {"git", "name-rev", "--name-only", "HEAD"};
-        String branch = first(execute(command, baseDirectory));
-        command = new String[]{"git", "config", "branch." + branch + ".remote"};
-        String remote = first(execute(command, baseDirectory));
-        command = new String[]{"git", "config", "remote." + remote + ".url"};
+        // Asks origin directly, matching build-git.gradle. The previous chain walked
+        // name-rev -> branch.<name>.remote -> remote.<name>.url, which yields nothing whenever
+        // HEAD sits on a tag: name-rev returns "tags/...", which is not a branch, so the middle
+        // lookup fails and the last command becomes the literal `git config remote.null.url`.
+        String[] command = {"git", "remote", "get-url", "origin"};
         return first(execute(command, baseDirectory));
     }
 


### PR DESCRIPTION
Project.exec was removed in Gradle 9, so every git invocation in build-git.gradle
threw and was swallowed by `catch (Exception e) { return "" }`. writeBuildFiles
writes each file only behind an `if (hash?.trim())` guard, so build.githash,
build.gitbranch and build.gitremoteurl silently stopped being written. build.date
survived because it is a plain file write with no exec, which made the jars look
healthy. Every fatjar built after nzshm-opensha's Gradle 9.5 upgrade (44def08,
2026-05-18) carries only .date.

build-git.gradle:
- Replace exec {} with a ProcessBuilder helper, which is not subject to Gradle
  API churn and lets the working directory be set explicitly. stderr is captured
  separately rather than merged, so an advisory git warning cannot end up inside
  a commit hash.
- Use `git remote get-url origin` instead of walking
  name-rev -> branch.<name>.remote -> remote.<name>.url. That chain yields
  nothing whenever HEAD sits on a tag, because name-rev returns "tags/..." and
  the middle lookup fails, leaving the literal `git config remote.null.url`.
- Warn on every failed command and every skipped file. The silent skips are why
  this shipped unnoticed for two months.

GitVersion.java:
- loadGitBranch: run against baseDirectory, like loadGitHash and loadGitRemote.
  It used the process cwd, so the branch of whatever repository happened to
  launch the JVM was recorded as this repository's branch - wrong, plausible
  looking data rather than absent data. Callers using the no-arg constructor are
  unaffected, since their baseDirectory already is new File("").
- execute: check the directory exists before spawning, so an absent checkout is
  one line instead of an IOException stack trace, and log the previously
  invisible non-zero-exit path.